### PR TITLE
Use const reference in for-loop for fix 

### DIFF
--- a/3rdparty/spirv-cross/spirv_reflect.cpp
+++ b/3rdparty/spirv-cross/spirv_reflect.cpp
@@ -552,7 +552,7 @@ void CompilerReflection::emit_specialization_constants()
 		return;
 
 	json_stream->emit_json_key_array("specialization_constants");
-	for (const auto spec_const : specialization_constants)
+	for (const auto& spec_const : specialization_constants)
 	{
 		auto &c = get<SPIRConstant>(spec_const.id);
 		auto type = get<SPIRType>(c.constant_type);


### PR DESCRIPTION
AppleClang 12 complains about unnecessary copies in for loops when using `-Werror`. Now this warning/error is actually in spirv-cross, but since you bundle that in this repository, I thought I'd open a PR here. 

It probably makes more sense to see if a newer version of spirv-cross than the one bundled here fixes this (I didn't test this), so feel free to close this.